### PR TITLE
fix: put tf-state-backup-bucket in flux-system namespace

### DIFF
--- a/kubernetes/apps/infrastructure/terraform/state-storage/secrets/backup-bucket.yaml
+++ b/kubernetes/apps/infrastructure/terraform/state-storage/secrets/backup-bucket.yaml
@@ -2,6 +2,6 @@ apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
   name: tf-state-backup-bucket
-  namespace: terraform
+  namespace: flux-system
 spec:
   itemPath: "vaults/Kubernetes/items/mich-cloudflare-r2-tf-state-database-backup-bucket"

--- a/kubernetes/apps/infrastructure/terraform/state-storage/secrets/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/terraform/state-storage/secrets/kustomization.yaml
@@ -2,7 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: terraform
 resources:
   - ./user-secret.yaml
   - ./backup-secret.yaml


### PR DESCRIPTION
To use this secret for substitution in the `terraform-state-storage` ks, it needs to live next to it in the same namespace. 