### PR TITLE
feat: allow branch tag for actions-runner image

### DIFF
--- a/.github/workflows/build-actions-runner.yaml
+++ b/.github/workflows/build-actions-runner.yaml
@@ -41,8 +41,6 @@ jobs:
             latest=false
           images: |
             name=ghcr.io/${{ github.repository_owner }}/actions-runner
-          tags: |
-            type=sha
 
       - name: Build and push image
         uses: docker/build-push-action@v6.5.0

--- a/kubernetes/apps/actions-runner/runners/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner/runners/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
       spec:
         initContainers:
         - name: init-dind-externals
-          image: ghcr.io/immich-app/actions-runner:sha-bf7b55c
+          image: ghcr.io/immich-app/actions-runner:main
           command: ["cp"]
           args: ["-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
           volumeMounts:
@@ -42,7 +42,7 @@ spec:
               mountPath: /home/runner/tmpDir
         containers:
         - name: runner
-          image: ghcr.io/immich-app/actions-runner:sha-bf7b55c
+          image: ghcr.io/immich-app/actions-runner:main
           imagePullPolicy: Always
           command: ["/home/runner/run.sh"]
           env:


### PR DESCRIPTION
This should allow renovate to push updates for this image into kube