### PR TITLE
chore: remove extraneous packages from actions-runner image

### DIFF
--- a/containers/actions-runner/Dockerfile
+++ b/containers/actions-runner/Dockerfile
@@ -16,15 +16,11 @@ RUN \
     && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
         gcc \
-        git \
         jo \
-        jq \
         make \
         moreutils \
         unrar \
-        unzip \
         wget \
         zip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Upstream now includes these by default since https://github.com/actions/runner/pull/3056