### PR TITLE
chore: manage hedgedoc oauth secret from tf

### DIFF
--- a/deployment/modules/1password/account/k8s-secrets.tf
+++ b/deployment/modules/1password/account/k8s-secrets.tf
@@ -95,3 +95,24 @@ resource "onepassword_item" "bot_github_webhook_slug" {
     }
   }
 }
+
+resource "random_password" "hedgedoc_oauth_secret" {
+  length  = 40
+  special = false
+}
+
+resource "onepassword_item" "hedgedoc_oauth_secret" {
+  vault    = data.onepassword_vault.kubernetes.uuid
+  title    = "hedgedoc-oauth"
+  category = "secure_note"
+
+  section {
+    label = "OAuth secret for hedgedoc"
+
+    field {
+      label = "CMD_OAUTH2_CLIENT_SECRET"
+      type  = "CONCEALED"
+      value = random_password.hedgedoc_oauth_secret.result
+    }
+  }
+}


### PR DESCRIPTION
Intent is for this to override the existing entry in 1password & continue working with the existing k8s setup.

Note, the tofu plan has some unexpected cloudflare stuff going on.