### PR TITLE
chore: up vmetrics maxUniqueTimeseries

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -42,4 +42,6 @@ spec:
       enabled: false
     vmsingle:
       spec:
+        extraArgs:
+          search.maxUniqueTimeseries: 600000
         resources: {}


### PR DESCRIPTION
The tileserver dashboards pretty quickly run up against this limit, while the vmetrics instance is still barely needing to do work at all.