### PR TITLE
fix: vmetrics extraArgs type

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -43,5 +43,5 @@ spec:
     vmsingle:
       spec:
         extraArgs:
-          search.maxUniqueTimeseries: 600000
+          search.maxUniqueTimeseries: "600000"
         resources: {}


### PR DESCRIPTION
Apparently this has to be a string, but the helm template run in the gha checks doesn't care to flag that 🤦