### PR TITLE
chore: remove fdroid redirect

### DIFF
--- a/tf/deployment/modules/cloudflare/account/redirects.tf
+++ b/tf/deployment/modules/cloudflare/account/redirects.tf
@@ -43,22 +43,6 @@ resource "cloudflare_ruleset" "immich_app_redirects" {
       from_value {
         status_code = 307
         target_url {
-          value = "https://f-droid.org/en/packages/app.alextran.immich/"
-        }
-        preserve_query_string = false
-      }
-    }
-    expression  = "(http.request.full_uri wildcard \"https://get*.immich.app/fdroid\")"
-    description = "Redirect get.immich.app/fdroid to the F-Droid"
-    enabled     = true
-  }
-
-  rules {
-    action = "redirect"
-    action_parameters {
-      from_value {
-        status_code = 307
-        target_url {
           value = "https://apps.apple.com/us/app/immich/id1613945652"
         }
         preserve_query_string = false


### PR DESCRIPTION
This redirect now lives in the ui repo (cloudflare pages project)