### PR TITLE
feat: use commit-sha tag for previews

### DIFF
--- a/kubernetes/apps/preview/github-prs/app/resource-set.yaml
+++ b/kubernetes/apps/preview/github-prs/app/resource-set.yaml
@@ -102,7 +102,7 @@ spec:
                   key: dbname
             LOG_LEVEL: verbose
           image:
-            tag: pr-<< inputs.id >>
+            tag: commit-<< inputs.sha >>
           server:
             image:
               pullPolicy: Always


### PR DESCRIPTION
This will break the existing preview envs until they merge main & build with the sha.