### PR TITLE
chore: longer timeout for preview HRs

### DIFF
--- a/kubernetes/apps/preview/github-previews/app/resource-set.yaml
+++ b/kubernetes/apps/preview/github-previews/app/resource-set.yaml
@@ -79,6 +79,7 @@ spec:
       namespace: preview
     spec:
       interval: 5m
+      timeout: 20m
       chart:
         spec:
           chart: immich


### PR DESCRIPTION
The previews sometimes get stuck in weird states. I think this is due to reconciliation timing out before the new image is available etc.