### PR TITLE
chore: bump max mich runners to 10

### DIFF
--- a/kubernetes/apps/actions-runner/runners/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner/runners/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
     runnerScaleSetName: mich
     githubConfigUrl: https://github.com/immich-app
     minRunners: 1
-    maxRunners: 3
+    maxRunners: 10
     githubConfigSecret: actions-controller-github-auth
     template:
       spec:


### PR DESCRIPTION
This is a temporary change until we get around to making different runner pools with actual CPU limits/quotas