### PR TITLE
fix: disableWait on preview HRs

### DIFF
--- a/kubernetes/apps/preview/github-previews/app/resource-set.yaml
+++ b/kubernetes/apps/preview/github-previews/app/resource-set.yaml
@@ -80,6 +80,10 @@ spec:
     spec:
       interval: 5m
       timeout: 20m
+      install:
+        disableWait: true
+      upgrade:
+        disableWait: true
       chart:
         spec:
           chart: immich


### PR DESCRIPTION
Hopefully this means they'll stop getting stuck and failing to clean up on delete