### PR TITLE
Revert "chore(deps): update grafana-operator docker tag to v5.18.0 (#591)

### DIFF
--- a/kubernetes/apps/infrastructure/operators/grafana-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/operators/grafana-operator/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: grafana-operator
-      version: v5.18.0
+      version: v5.17.1
       interval: 15m
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This reverts commit 6c3450c66193ee1323b0995e7bc983ff0eb9badd.