### PR TITLE
fix: use updateStrategy Restart for ingress-nginx

### DIFF
--- a/kubernetes/apps/infrastructure/networking/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/networking/ingress-nginx/app/helmrelease.yaml
@@ -40,6 +40,8 @@ spec:
         annotations-risk-level: Critical
       metrics:
         enabled: false
+      updateStrategy:
+        type: Restart
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
Because it binds directly to the host port and there's only one of those