### PR TITLE
fix: low worker-shutdown-timeout for ingress-nginx

### DIFF
--- a/kubernetes/apps/infrastructure/networking/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/networking/ingress-nginx/app/helmrelease.yaml
@@ -38,6 +38,7 @@ spec:
       config:
         allow-snippet-annotations: true
         annotations-risk-level: Critical
+        worker-shutdown-timeout: "10s"
       metrics:
         enabled: false
       updateStrategy:


### PR DESCRIPTION
On upgrades, the old pod is shut down before the new one starts (for port binding reasons). The shutdown waits a long time, 240s by default, for connections to gracefully terminate - which doesn't happen because of open websockets, usually on the demo. This sets that limit low to kill those connections instead.