### PR TITLE
chore: use other webhook domain

### DIFF
--- a/tf/deployment/modules/shared/github/webhooks/webhooks.tf
+++ b/tf/deployment/modules/shared/github/webhooks/webhooks.tf
@@ -11,7 +11,7 @@ resource "github_organization_webhook" "bot" {
     "release"
   ]
   configuration {
-    url          = "https://api.immich.app/webhooks/github/${data.onepassword_item.bot.password}"
+    url          = "https://discord-webhooks.immich.cloud/webhooks/github/${data.onepassword_item.bot.password}"
     content_type = "json"
   }
 }


### PR DESCRIPTION
I want to use the `api.immich.app` domain for a new static-site related to api documentation, so moving old usages to the *.immich.cloud domain instead.