### PR TITLE
feat: services repo

### DIFF
--- a/tf/deployment/modules/shared/github/org/repositories.tf
+++ b/tf/deployment/modules/shared/github/org/repositories.tf
@@ -92,6 +92,10 @@ variable "repositories" {
       description = "Tools for exporting and benchmarking the ML models used by Immich."
     },
     {
+      name        = "services",
+      description = "Assortment of services, apis, webhooks, and other misc things."
+    },
+    {
       name                   = "one-click",
       description            = "One-Click deployment for Immich on various platforms.",
       license                = "MIT",


### PR DESCRIPTION
If someone cares about the name being something else we can change it.

Somewhere for a bunch of random things like apis, webhooks, etc to live.

One example is the github actions check bot we want to build for approval/merge checks