### PR TITLE
Customize login page of preview envs to overcome misdetection by Safe Browsing

### DIFF
--- a/kubernetes/apps/preview/github-previews/app/resource-set.yaml
+++ b/kubernetes/apps/preview/github-previews/app/resource-set.yaml
@@ -137,6 +137,18 @@ spec:
               annotations:
                 cert-manager.io/cluster-issuer: letsencrypt-production
                 nginx.ingress.kubernetes.io/proxy-body-size: "0"
+                nginx.ingress.kubernetes.io/configuration-snippet: |
+                  # UI tweaks: login page banner (html), subdued logo (javascript)
+                  sub_filter_types text/html text/javascript;
+                  sub_filter_once off;
+                  sub_filter '<body class="bg-light text-dark">' '<body class="bg-light text-dark"><div id="custom-banner" style="display: flex; justify-content: center; padding: 20px;">$host<br>This is a preview instance.<br>Use developer credentials to log in.</div>';
+                  sub_filter "fa2921" "aaaaaa";
+                  sub_filter "ed79b5" "aaaaaa";
+                  sub_filter "ffb400" "aaaaaa";
+                  sub_filter "1e83f7" "aaaaaa";
+                  sub_filter "18c249" "aaaaaa";
+                  # required for subdued logo (replacement in js files: http_sub_module doesn't support compression between ingress and backend)
+                  proxy_set_header Accept-Encoding "";
               hosts:
                 - host: << $ctx.name >>.preview.internal.immich.cloud
                   paths:
@@ -149,4 +161,3 @@ spec:
         machine-learning:
           image:
             pullPolicy: Always
-


### PR DESCRIPTION
To overcome google's misclassification of preview environments at immich.cloud as deceptive/phishing, I suggest an experiment: **modify the login page to look different compared to Immich demo.**
- Add a text banner
- Make logo subdued (or remove it from the login page altogether?)
- Something else?

A quick proof of concept is done at ingress level. Admittedly, there must be more natural ways of accomplishing this instead of tinkering with ingress. But I have a hammer, so everything looks like substring replacement 😄

Tested with minimal k8s manifests on my ingress, so it may not work as expected in the devtools project.
<details><summary>Screenshot</summary>
<img width="1042" height="879" alt="image" src="https://github.com/user-attachments/assets/74bed428-7e8c-4361-8588-e1b6663b8d14" />
</details>

### Context

The nagging google's / safe browsing misclassification of self-hosted software as deceptive can be triggered for various reasons, they don't provide an explanation. Among discussed over internet:
- References to 3rd party (the page resembles original web sites), e.g. layout, logo, meta, ...
- Domain name containing 3rd party name
- Redirects: permanent vs temporary
- HTTP Security Headers rating (https://securityheaders.com)
- ...

This PR is aimed to test the first point:
- if a project has a demo instance with a default login page (demo.immich.app, demo.jellyfin.org, demo1.nextcloud.com) that is classified as "primary" by google's algorithms
- then any self-hosted instance with the same login page (branding, title, logo, meta) becomes a candidate for deceptive/phishing by that algorithm. And immich.cloud has a lot of preview envs falling in that category.

Affected projects
- Immich https://www.answeroverflow.com/m/1420678608401469440, https://www.reddit.com/r/immich/comments/1ne5jbq/google_has_blocked_my_domain_due_to_immich/
- Jellyfin https://github.com/jellyfin/jellyfin-web/issues/4076
- Yunohost https://forum.yunohost.org/t/google-flags-my-sites-as-dangerous-deceptive-site-ahead/20361
- n8n https://community.n8n.io/t/deceptive-site-ahead-urgent/24152
- Nextcloud https://www.reddit.com/r/NextCloud/comments/w3x0fs/google_marked_my_nextcloud_app_as_a_dangerous/
