### PR TITLE
fix: tune vmsingle resource limits and query settings

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -47,13 +47,19 @@ spec:
     vmsingle:
       spec:
         extraArgs:
-          search.maxUniqueTimeseries: "600000"
+          search.logSlowQueryDuration: "3s"
         resources:
+          requests:
+            cpu: 2000m
+            memory: 32Gi
           limits:
-            memory: 8Gi
+            memory: 32Gi
     vmagent:
       spec:
         resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
           limits:
             cpu: 2000m
             memory: 1Gi


### PR DESCRIPTION
- remove explicit search.maxUniqueTimeseries cap (600k) to let vm auto-calculate (~4.3m with 32gi)
- add search.logSlowQueryDuration for query observability
- bump vmsingle memory from 8gi to 32gi with proper requests
- add cpu/memory requests for both vmsingle and vmagent