### PR TITLE
feat: expose working_directory to mise-action

### DIFF
--- a/actions/use-mise/action.yml
+++ b/actions/use-mise/action.yml
@@ -4,12 +4,16 @@ inputs:
   github-token:
     description: 'Github token to use'
     required: true
+  working_directory:
+    required: false
+    description: 'The directory that mise runs in'
 runs:
   using: 'composite'
   steps:
     - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         github_token: ${{ inputs.GITHUB_TOKEN }}
+        working_directory: ${{ inputs.working_directory }}
         version: 2026.3.13
         sha256: ${{ runner.os == 'Linux' && runner.arch == 'X64' && '806790b4a71c93d20e027c40ddf38470fa6e26555275b1181a3c2ccc082ef56f' ||
                  runner.os == 'Linux' && runner.arch == 'ARM64' && 'c1f56fd3c44a219bbb7064af240b4d3c3e4697b4d88377b8c52576f9a572627e' ||


### PR DESCRIPTION
allow passing [`working_directory`](https://github.com/jdx/mise-action/blob/main/action.yml#L63) so we use mise tasks in immich in CI. see https://github.com/immich-app/immich/pull/25579