### PR TITLE
fix: add vmauth token for o11y clusters

### DIFF
--- a/tf/deployment/modules/shared/1password/futo-account/yucca-secrets.tf
+++ b/tf/deployment/modules/shared/1password/futo-account/yucca-secrets.tf
@@ -44,7 +44,9 @@ module "yucca-generated-secrets" {
 
   secrets = {
     global = []
-    scoped = []
+    scoped = [
+      { name = "VICTORIAMETRICS_VMAUTH_PASSWORD" },
+    ]
   }
 
   global_vault = "yucca_tf"


### PR DESCRIPTION
Creates a generated token for vmauth in the o11y cluster