### PR TITLE
fix: add postgres passwords for o11y clusters

### DIFF
--- a/tf/deployment/modules/shared/1password/futo-account/yucca-secrets.tf
+++ b/tf/deployment/modules/shared/1password/futo-account/yucca-secrets.tf
@@ -46,6 +46,8 @@ module "yucca-generated-secrets" {
     global = []
     scoped = [
       { name = "VICTORIAMETRICS_VMAUTH_PASSWORD" },
+      { name = "POSTGRES_SUPERUSER_PASSWORD" },
+      { name = "POSTGRES_GRAFANA_PASSWORD" },
     ]
   }
 


### PR DESCRIPTION
We will be running cnpg in-order to scale grafana