### PR TITLE
fix(o11y): add grafana session secret to 1p

### DIFF
--- a/tf/deployment/modules/shared/1password/futo-account/yucca-secrets.tf
+++ b/tf/deployment/modules/shared/1password/futo-account/yucca-secrets.tf
@@ -48,6 +48,7 @@ module "yucca-generated-secrets" {
       { name = "VICTORIAMETRICS_VMAUTH_PASSWORD" },
       { name = "POSTGRES_SUPERUSER_PASSWORD" },
       { name = "POSTGRES_GRAFANA_PASSWORD" },
+      { name = "GRAFANA_SECRET_KEY" },
     ]
   }
 


### PR DESCRIPTION
When running multiples of grafana (backed by pg) a shared session secret is needed to retain login when pods restart