### PR TITLE
fix(netbird): change peer expiration to be 7 days

### DIFF
--- a/tf/deployment/modules/shared/netbird/account/account-settings.tf
+++ b/tf/deployment/modules/shared/netbird/account/account-settings.tf
@@ -18,4 +18,9 @@ resource "netbird_account_settings" "default" {
 
   # Custom DNS domain peers are addressable under (e.g. <peer>.futo.network).
   dns_domain = "futo.network"
+
+  # Force peers to re-authenticate (SSO login) periodically. After this much
+  # time since last login a peer's session expires and it must log in again.
+  peer_login_expiration_enabled = true
+  peer_login_expiration         = 7 * 24 * 60 * 60 # 7 days, in seconds
 }

--- a/tf/deployment/modules/shared/netbird/account/config.tf
+++ b/tf/deployment/modules/shared/netbird/account/config.tf
@@ -5,9 +5,14 @@ terraform {
   required_version = "~> 1.7"
 
   required_providers {
+    # Fork of netbirdio/netbird that fixes the group resources<->map conversion
+    # crash so a group attached to a network_resource can be updated (e.g. to
+    # set peers). Published to the Terraform Registry, so the source is
+    # fully-qualified to fetch from registry.terraform.io rather than OpenTofu's
+    # default registry. See futo-org/terraform-provider-netbird.
     netbird = {
-      source  = "netbirdio/netbird"
-      version = "0.0.9"
+      source  = "registry.terraform.io/futo-org/netbird"
+      version = "1.0.1"
     }
     onepassword = {
       source  = "1Password/onepassword"


### PR DESCRIPTION
It's incredibly annoying at 24 hours and right now tailscale never re-auths.