### PR TITLE
fix: quote txt record content for futo cloudflare dns

### DIFF
--- a/tf/deployment/modules/shared/cloudflare/futo-account/dns-as402421-net.tf
+++ b/tf/deployment/modules/shared/cloudflare/futo-account/dns-as402421-net.tf
@@ -49,7 +49,7 @@ resource "cloudflare_dns_record" "as402421_net_txt_spf" {
   zone_id = cloudflare_zone.as402421_net.id
   name    = "as402421.net"
   type    = "TXT"
-  content = "v=spf1 include:spf.messagingengine.com -all"
+  content = "\"v=spf1 include:spf.messagingengine.com -all\""
   ttl     = 1
   proxied = false
 }
@@ -58,7 +58,7 @@ resource "cloudflare_dns_record" "as402421_net_txt_dmarc" {
   zone_id = cloudflare_zone.as402421_net.id
   name    = "_dmarc.as402421.net"
   type    = "TXT"
-  content = "v=DMARC1; p=reject; rua=mailto:2225ea925e8d4b4580af7e5744f181db@dmarc-reports.cloudflare.net"
+  content = "\"v=DMARC1; p=reject; rua=mailto:2225ea925e8d4b4580af7e5744f181db@dmarc-reports.cloudflare.net\""
   ttl     = 1
   proxied = false
 }

--- a/tf/deployment/modules/shared/cloudflare/futo-account/dns-futo-cloud.tf
+++ b/tf/deployment/modules/shared/cloudflare/futo-account/dns-futo-cloud.tf
@@ -49,7 +49,7 @@ resource "cloudflare_dns_record" "futo_cloud_txt_spf" {
   zone_id = cloudflare_zone.futo_cloud.id
   name    = "futo.cloud"
   type    = "TXT"
-  content = "v=spf1 include:spf.messagingengine.com -all"
+  content = "\"v=spf1 include:spf.messagingengine.com -all\""
   ttl     = 1
   proxied = false
 }
@@ -58,7 +58,7 @@ resource "cloudflare_dns_record" "futo_cloud_txt_dmarc" {
   zone_id = cloudflare_zone.futo_cloud.id
   name    = "_dmarc.futo.cloud"
   type    = "TXT"
-  content = "v=DMARC1; p=reject; rua=mailto:bd9ccdafc3b44a88968d1f9889c853d9@dmarc-reports.cloudflare.net"
+  content = "\"v=DMARC1; p=reject; rua=mailto:bd9ccdafc3b44a88968d1f9889c853d9@dmarc-reports.cloudflare.net\""
   ttl     = 1
   proxied = false
 }


### PR DESCRIPTION
cloudflare expects txt record values wrapped in double quotes, matching the immich dns records.