### PR TITLE
ci: render flux diffs with flate instead of flux-local

### DIFF
--- a/.github/workflows/flux-diff.yml
+++ b/.github/workflows/flux-diff.yml
@@ -13,27 +13,33 @@ jobs:
       contents: read
       packages: read
       pull-requests: write
-    strategy:
-      matrix:
-        resource: ["helmrelease", "kustomization"]
     steps:
-      - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@1fd61a06264d71cf445ed55c4f14d401d26a1c64 # v2.8.8
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Setup flate
+        uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
+        with:
+          base: "origin/${{ github.event.pull_request.base.ref }}"
+          cache: true
 
       - name: Diff Resources
-        uses: allenporter/flux-local/action/diff@88f56a2113aeda1551111d446734e9f4a4bee7d4 # 8.3.0
         id: diff
-        with:
-          path: "./kubernetes"
-          live-branch: "${{ github.event.pull_request.base.ref }}"
-          resource: "${{ matrix.resource }}"
-          skip-crds: "false"
+        run: |
+          flate diff all --path ./kubernetes --allow-missing-secrets -o github > diff.txt
+          {
+            echo 'diff<<DIFF_EOF'
+            cat diff.txt
+            echo 'DIFF_EOF'
+          } >> "${GITHUB_OUTPUT}"
 
       - if: ${{ steps.diff.outputs.diff != '' }}
         name: Add comment
         uses: immich-app/devtools/actions/sticky-comment@0135acd12ad9f3369b94a2aa3c0ae8c835a4e926 # sticky-comment-action-v1.0.0
         with:
-          id: "flux-diff/${{ matrix.path }}/${{ matrix.resource }}"
+          id: "flux-diff"
           body: |
             ```diff
             ${{ steps.diff.outputs.diff }}


### PR DESCRIPTION
Step 2 of 2 of the [`flux-local`](https://github.com/allenporter/flux-local) → [`flate`](https://github.com/home-operations/flate) migration.

> [!IMPORTANT]
> Merge **after** #1766. That PR bakes the `github-previews` ResourceSet inputs onto `main`; without them the new workflow can't render that stack offline. This PR touches only the workflow file, so its own Flux Diff check reconciles nothing (changed-only mode) and passes regardless — but the *next* kubernetes PR needs #1766 already on `main`.

## Changes
- Replace `fluxcd/flux2` + `allenporter/flux-local` action with `home-operations/flate/action` + `flate diff all`.
- flate is one static binary that renders fully offline, so the Flux CLI setup and the hr/ks matrix collapse into a single job.
- Add `actions/checkout` at `fetch-depth: 0` (the flate action doesn't check out, and `--base` needs the base ref materializable).
- `--allow-missing-secrets` covers the 16 `OnePasswordItem`-generated secrets (flate auto-skips ExternalSecrets but not those; cert/proxy secrets still fail loud).

## Note
The single job is named `Flux Diff`; the old matrix produced `Flux Diff (helmrelease)` / `(kustomization)`. If branch protection requires those check names, update it to require `Flux Diff`.