### PR TITLE
fix: add transform rules write perm to tf CF token

### DIFF
--- a/tf/deployment/modules/shared/cloudflare/api-keys/api-keys.tf
+++ b/tf/deployment/modules/shared/cloudflare/api-keys/api-keys.tf
@@ -9,6 +9,7 @@ resource "cloudflare_api_token" "terraform_cloudflare_account" {
       data.cloudflare_api_token_permission_groups.all.zone["Zone Write"],
       data.cloudflare_api_token_permission_groups.all.zone["Zone Settings Write"],
       data.cloudflare_api_token_permission_groups.all.zone["Dynamic URL Redirects Write"],
+      data.cloudflare_api_token_permission_groups.all.zone["Zone Transform Rules Write"],
       data.cloudflare_api_token_permission_groups.all.account["Workers R2 Storage Write"],
       data.cloudflare_api_token_permission_groups.all.account["Notifications Read"],
       data.cloudflare_api_token_permission_groups.all.account["Notifications Write"],


### PR DESCRIPTION
   │ Error: error creating ruleset Preview noindex
  │ 
  │   with cloudflare_ruleset.immich_app_preview_noindex,
  │   on noindex.tf line 1, in resource "cloudflare_ruleset" "immich_app_preview_noindex":
  │    1: resource "cloudflare_ruleset" "immich_app_preview_noindex" {
  │ 
  │ request is not authorized
