### PR TITLE
feat: enable vmalert with version worker recording rules

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -39,7 +39,26 @@ spec:
     alertmanager:
       enabled: false
     vmalert:
-      enabled: false
+      enabled: true
+      spec:
+        # Only evaluate our own VMRule (recording rules). The chart's
+        # defaultRules VMRules in this namespace are alerting rules with no
+        # notifier configured, so we select explicitly by label instead of
+        # using the chart default selectAllByDefault: true.
+        selectAllByDefault: false
+        ruleSelector:
+          matchLabels:
+            immich.app/vmrule: version-worker
+        extraArgs:
+          # No alertmanager is deployed; vmalert only runs recording rules.
+          notifier.blackhole: "true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi
     grafana:
       enabled: false
     kubeEtcd:

--- a/kubernetes/apps/monitoring/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./vmrule-version-worker.yaml

--- a/kubernetes/apps/monitoring/victoria-metrics/app/vmrule-version-worker.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/vmrule-version-worker.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: version-worker-recording
+  namespace: monitoring
+  labels:
+    immich.app/vmrule: version-worker
+spec:
+  groups:
+    # Per-5m markers computed over raw data.
+    - name: version-worker.base
+      interval: 5m
+      rules:
+        - record: version:server_seen:count5m
+          expr: |-
+            count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+        - record: version:server_seen_vreq:count5m
+          expr: |-
+            count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+        - record: version:server_seen_continent:count5m
+          expr: |-
+            count by (client_ip, continent) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+        - record: version:server_version_seen:count5m
+          expr: |-
+            count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+        - record: version:server_version_seen_vreq:count5m
+          expr: |-
+            count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+        - record: version:requests:count5m
+          expr: |-
+            sum(count_over_time(version_handle_request_invocation[5m]))
+        - record: version:requests_by_colo:count5m
+          expr: |-
+            sum by (colo) (count_over_time(version_handle_request_invocation{colo!=""}[5m]))
+        - record: version:memory_cache_hit:count5m
+          expr: |-
+            sum(count_over_time(version_memory_cache_hit_count[5m]))
+        - record: version:memory_cache_stale:count5m
+          expr: |-
+            sum(count_over_time(version_memory_cache_stale_count[5m]))
+        - record: version:memory_cache_miss:count5m
+          expr: |-
+            sum(count_over_time(version_memory_cache_miss_count[5m]))
+        - record: version:requests_immich:count5m
+          expr: |-
+            (sum(count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m])) or vector(0))
+        - record: version:requests_other:count5m
+          expr: |-
+            (sum(count_over_time(version_version_request_invocation{user_agent!~"immich-server/.*",user_agent!=""}[5m])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent!~"immich-server/.*",user_agent!=""}[5m])) or vector(0))
+
+    # Derived from base rule series only (never raw). eval_offset ensures the
+    # async remote-write of the base group has landed before evaluation.
+    - name: version-worker.derived
+      interval: 5m
+      eval_offset: 2m30s
+      rules:
+        - record: version:servers_unique:2h
+          expr: |-
+            count(count_over_time(version:server_seen:count5m[2h]))
+        - record: version:servers_unique:24h
+          expr: |-
+            count(count_over_time(version:server_seen:count5m[24h]))
+        - record: version:servers_new:5m
+          expr: |-
+            count(count_over_time(version:server_seen:count5m[5m]) unless count_over_time(version:server_seen:count5m[30d] offset 5m))
+        - record: version:servers_new:1h
+          expr: |-
+            count(count_over_time(version:server_seen:count5m[1h]) unless count_over_time(version:server_seen:count5m[30d] offset 1h))
+        - record: version:servers_upgrades:1h
+          expr: |-
+            count(count by (client_ip) (count_over_time(version:server_version_seen_vreq:count5m[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) and count_over_time(version:server_seen_vreq:count5m[30d] offset 1h))
+        - record: version:servers_new_installs:1h
+          expr: |-
+            count(count by (client_ip) (count_over_time(version:server_version_seen_vreq:count5m[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) unless count_over_time(version:server_seen_vreq:count5m[30d] offset 1h))
+        - record: version:servers_by_version:24h
+          expr: |-
+            count by (user_agent) (count_over_time(version:server_version_seen:count5m[24h]))
+        - record: version:servers_by_version_vreq:2h
+          expr: |-
+            count by (user_agent) (count_over_time(version:server_version_seen_vreq:count5m[2h]))
+        - record: version:servers_by_continent:24h
+          expr: |-
+            count by (continent) (count_over_time(version:server_seen_continent:count5m[24h]))
+        - record: version:servers_uptodate_ratio:24h
+          expr: |-
+            count(count by (client_ip, user_agent) (count_over_time(version:server_version_seen_vreq:count5m[24h])) and on(user_agent) last_over_time(version_latest_version_count[3h])) / count(count_over_time(version:server_seen_vreq:count5m[24h]))
+        - record: version:servers_ipv4:24h
+          expr: |-
+            count(count_over_time(version:server_seen:count5m{client_ip!~".*:.*",client_ip!=""}[24h]))
+        - record: version:servers_ipv6:24h
+          expr: |-
+            count(count_over_time(version:server_seen:count5m{client_ip=~".*:.*"}[24h]))
+
+    # Slow-moving 30d aggregates.
+    - name: version-worker.derived-30d
+      interval: 30m
+      eval_offset: 2m30s
+      rules:
+        - record: version:servers_unique:30d
+          expr: |-
+            count(count_over_time(version:server_seen:count5m[30d]))
+        - record: version:servers_new:1d
+          expr: |-
+            count(count_over_time(version:server_seen:count5m[1d]) unless count_over_time(version:server_seen:count5m[30d] offset 1d))

--- a/kubernetes/apps/monitoring/victoria-metrics/ks.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/ks.yaml
@@ -67,4 +67,27 @@ spec:
         name: victoriametrics-backup-bucket
       - kind: Secret
         name: victoriametrics-backup-secret
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vmetrics-replay
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: vmetrics-replay
+  dependsOn:
+    - name: victoria-metrics
+  path: ./kubernetes/apps/monitoring/victoria-metrics/replay
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: immich-kubernetes
+  # wait deliberately off: the replay Job can run for a long time; flux should
+  # apply it and move on rather than flap on health-check timeouts.
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
 

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/README.md
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/README.md
@@ -1,0 +1,45 @@
+# vmalert replay — version-worker recording rules backfill
+
+One-off backfill of history for the recording rules defined in
+`../app/vmrule-version-worker.yaml`. This directory is **not** referenced by any
+flux Kustomization — it is inert until applied manually.
+
+## Runbook
+
+1. Edit `job.yaml`: set both `-replay.timeFrom` placeholders to the same
+   RFC3339 timestamp, normally `now-31d` (e.g. `2026-06-19T00:00:00Z`).
+2. Apply and wait for completion:
+
+   ```sh
+   kubectl apply -f configmap-rules.yaml -f job.yaml
+   kubectl -n monitoring wait --for=condition=complete --timeout=2h job/version-worker-replay
+   ```
+
+3. Reset the vmsingle rollup result cache so queries immediately see the
+   backfilled samples (run from any pod in the `monitoring` namespace):
+
+   ```sh
+   curl -s http://vmsingle-vmetrics:8428/internal/resetRollupResultCache
+   ```
+
+4. Clean up:
+
+   ```sh
+   kubectl -n monitoring delete job/version-worker-replay
+   kubectl -n monitoring delete configmap/version-worker-replay-rules
+   ```
+
+## Notes
+
+- The base group must be replayed before the derived groups, because the
+  derived rules query the base rule series. The Job enforces this: the
+  initContainer replays `base.yaml`, then the main container replays
+  `derived.yaml`.
+- Replayed points whose lookbehind window crosses the retention horizon (e.g.
+  `[30d]` windows evaluated near the start of retained raw data) are lower
+  bounds, not exact values.
+- If vmalert is down for a period later on, the rule series will have holes for
+  that period unless the affected window is re-replayed.
+- `configmap-rules.yaml` must be kept in sync with
+  `../app/vmrule-version-worker.yaml` whenever the rules change — the replay
+  files are a plain vmalert rule-file copy of the VMRule groups.

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/README.md
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/README.md
@@ -1,40 +1,50 @@
 # vmalert replay — version-worker recording rules backfill
 
 One-off backfill of history for the recording rules defined in
-`../app/vmrule-version-worker.yaml`. This directory is **not** referenced by any
-flux Kustomization — it is inert until applied manually.
+`../app/vmrule-version-worker.yaml`. Flux applies this directory once via the
+`vmetrics-replay` Kustomization in `../ks.yaml` (after `victoria-metrics`, so
+vmsingle, vmalert, and the VMRule are already in place). No manual steps are
+needed on merge.
 
-## Runbook
+The Job:
 
-1. Edit `job.yaml`: set both `-replay.timeFrom` placeholders to the same
-   RFC3339 timestamp, normally `now-31d` (e.g. `2026-06-19T00:00:00Z`).
-2. Apply and wait for completion:
+1. replays the base group (`base.yaml`) from `-replay.timeFrom` to now,
+2. then replays the derived groups (`derived.yaml`), which read the base rule
+   series (ordering enforced by the pod's initContainer sequence),
+3. then resets the vmsingle rollup result cache so queries immediately see the
+   backfilled samples.
 
-   ```sh
-   kubectl apply -f configmap-rules.yaml -f job.yaml
-   kubectl -n monitoring wait --for=condition=complete --timeout=2h job/version-worker-replay
-   ```
+`-replay.timeFrom` is checked in as ~31d before the expected merge date. If the
+merge slips past it, the early part of the window simply falls outside raw
+retention and produces empty points — no action needed.
 
-3. Reset the vmsingle rollup result cache so queries immediately see the
-   backfilled samples (run from any pod in the `monitoring` namespace):
+## Monitoring
 
-   ```sh
-   curl -s http://vmsingle-vmetrics:8428/internal/resetRollupResultCache
-   ```
+```sh
+kubectl -n monitoring logs -f job/version-worker-replay -c replay-base
+kubectl -n monitoring logs -f job/version-worker-replay -c replay-derived
+kubectl -n monitoring wait --for=condition=complete --timeout=2h job/version-worker-replay
+```
 
-4. Clean up:
+## Cleanup
 
-   ```sh
-   kubectl -n monitoring delete job/version-worker-replay
-   kubectl -n monitoring delete configmap/version-worker-replay-rules
-   ```
+After the job completes and the rule series validate against the raw queries
+(see the "Recording Rule Validation" row on the Version Worker Server Analytics
+dashboard): remove this directory and the `vmetrics-replay` Kustomization from
+`../ks.yaml` in a follow-up PR — `prune: true` then deletes the Job and
+ConfigMap.
+
+## Re-running
+
+Jobs are immutable, so the Job carries the `kustomize.toolkit.fluxcd.io/force`
+annotation: flux will delete+recreate (and therefore re-run the replay) on any
+spec change. To re-run a window, edit `-replay.timeFrom` in `job.yaml` and let
+flux reconcile. Note that manually deleting the completed Job also makes flux
+recreate it on the next reconciliation — a re-replay overwrites the same
+historical points with identical values, so this is harmless but heavy.
 
 ## Notes
 
-- The base group must be replayed before the derived groups, because the
-  derived rules query the base rule series. The Job enforces this: the
-  initContainer replays `base.yaml`, then the main container replays
-  `derived.yaml`.
 - Replayed points whose lookbehind window crosses the retention horizon (e.g.
   `[30d]` windows evaluated near the start of retained raw data) are lower
   bounds, not exact values.

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/configmap-rules.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/configmap-rules.yaml
@@ -1,6 +1,6 @@
 ---
 # Rule files for one-off vmalert replay (backfill of recording rule history).
-# NOT reconciled by flux — apply manually, see README.md.
+# Applied once by flux (ks.yaml: vmetrics-replay) together with job.yaml; see README.md.
 # MUST be kept in sync with app/vmrule-version-worker.yaml if rules change.
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/configmap-rules.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/configmap-rules.yaml
@@ -1,0 +1,103 @@
+---
+# Rule files for one-off vmalert replay (backfill of recording rule history).
+# NOT reconciled by flux — apply manually, see README.md.
+# MUST be kept in sync with app/vmrule-version-worker.yaml if rules change.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: version-worker-replay-rules
+  namespace: monitoring
+data:
+  base.yaml: |
+    groups:
+      - name: version-worker.base
+        interval: 5m
+        rules:
+          - record: version:server_seen:count5m
+            expr: |-
+              count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+          - record: version:server_seen_vreq:count5m
+            expr: |-
+              count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+          - record: version:server_seen_continent:count5m
+            expr: |-
+              count by (client_ip, continent) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+          - record: version:server_version_seen:count5m
+            expr: |-
+              count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+          - record: version:server_version_seen_vreq:count5m
+            expr: |-
+              count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m]))
+          - record: version:requests:count5m
+            expr: |-
+              sum(count_over_time(version_handle_request_invocation[5m]))
+          - record: version:requests_by_colo:count5m
+            expr: |-
+              sum by (colo) (count_over_time(version_handle_request_invocation{colo!=""}[5m]))
+          - record: version:memory_cache_hit:count5m
+            expr: |-
+              sum(count_over_time(version_memory_cache_hit_count[5m]))
+          - record: version:memory_cache_stale:count5m
+            expr: |-
+              sum(count_over_time(version_memory_cache_stale_count[5m]))
+          - record: version:memory_cache_miss:count5m
+            expr: |-
+              sum(count_over_time(version_memory_cache_miss_count[5m]))
+          - record: version:requests_immich:count5m
+            expr: |-
+              (sum(count_over_time(version_version_request_invocation{user_agent=~"immich-server/.*"}[5m])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent=~"immich-server/.*"}[5m])) or vector(0))
+          - record: version:requests_other:count5m
+            expr: |-
+              (sum(count_over_time(version_version_request_invocation{user_agent!~"immich-server/.*",user_agent!=""}[5m])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent!~"immich-server/.*",user_agent!=""}[5m])) or vector(0))
+  derived.yaml: |
+    groups:
+      - name: version-worker.derived
+        interval: 5m
+        eval_offset: 2m30s
+        rules:
+          - record: version:servers_unique:2h
+            expr: |-
+              count(count_over_time(version:server_seen:count5m[2h]))
+          - record: version:servers_unique:24h
+            expr: |-
+              count(count_over_time(version:server_seen:count5m[24h]))
+          - record: version:servers_new:5m
+            expr: |-
+              count(count_over_time(version:server_seen:count5m[5m]) unless count_over_time(version:server_seen:count5m[30d] offset 5m))
+          - record: version:servers_new:1h
+            expr: |-
+              count(count_over_time(version:server_seen:count5m[1h]) unless count_over_time(version:server_seen:count5m[30d] offset 1h))
+          - record: version:servers_upgrades:1h
+            expr: |-
+              count(count by (client_ip) (count_over_time(version:server_version_seen_vreq:count5m[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) and count_over_time(version:server_seen_vreq:count5m[30d] offset 1h))
+          - record: version:servers_new_installs:1h
+            expr: |-
+              count(count by (client_ip) (count_over_time(version:server_version_seen_vreq:count5m[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) unless count_over_time(version:server_seen_vreq:count5m[30d] offset 1h))
+          - record: version:servers_by_version:24h
+            expr: |-
+              count by (user_agent) (count_over_time(version:server_version_seen:count5m[24h]))
+          - record: version:servers_by_version_vreq:2h
+            expr: |-
+              count by (user_agent) (count_over_time(version:server_version_seen_vreq:count5m[2h]))
+          - record: version:servers_by_continent:24h
+            expr: |-
+              count by (continent) (count_over_time(version:server_seen_continent:count5m[24h]))
+          - record: version:servers_uptodate_ratio:24h
+            expr: |-
+              count(count by (client_ip, user_agent) (count_over_time(version:server_version_seen_vreq:count5m[24h])) and on(user_agent) last_over_time(version_latest_version_count[3h])) / count(count_over_time(version:server_seen_vreq:count5m[24h]))
+          - record: version:servers_ipv4:24h
+            expr: |-
+              count(count_over_time(version:server_seen:count5m{client_ip!~".*:.*",client_ip!=""}[24h]))
+          - record: version:servers_ipv6:24h
+            expr: |-
+              count(count_over_time(version:server_seen:count5m{client_ip=~".*:.*"}[24h]))
+      - name: version-worker.derived-30d
+        interval: 30m
+        eval_offset: 2m30s
+        rules:
+          - record: version:servers_unique:30d
+            expr: |-
+              count(count_over_time(version:server_seen:count5m[30d]))
+          - record: version:servers_new:1d
+            expr: |-
+              count(count_over_time(version:server_seen:count5m[1d]) unless count_over_time(version:server_seen:count5m[30d] offset 1d))

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/job.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/job.yaml
@@ -1,14 +1,24 @@
 ---
-# One-off vmalert replay Job to backfill recording rule history.
-# NOT reconciled by flux — apply manually, see README.md.
-# The initContainer replays the base group first; the main container then
-# replays the derived groups, which read the base rule series. This ordering
-# is required and enforced by the Job structure.
+# One-off vmalert replay Job to backfill recording rule history, applied once
+# by flux (ks.yaml: vmetrics-replay). Once it has completed and the rule series
+# validate, remove this directory and the vmetrics-replay Kustomization in a
+# follow-up PR — prune will delete the Job and ConfigMap.
+#
+# Ordering is required and enforced by the pod structure: the base group is
+# replayed first, then the derived groups (which read the base rule series),
+# then the vmsingle rollup result cache is reset so queries immediately see
+# the backfilled samples.
+#
+# Jobs are immutable; the force annotation makes flux delete+recreate (and
+# therefore re-run the replay) if this spec is ever changed. To re-run with a
+# different window, edit -replay.timeFrom and let flux recreate the Job.
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: version-worker-replay
   namespace: monitoring
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: "true"
 spec:
   backoffLimit: 0
   template:
@@ -25,28 +35,33 @@ spec:
             - -rule=/rules/base.yaml
             - -datasource.url=http://vmsingle-vmetrics:8428
             - -remoteWrite.url=http://vmsingle-vmetrics:8428
-            # EDIT ME before applying: RFC3339 start of the backfill window,
-            # normally now-31d (e.g. 2026-06-19T00:00:00Z).
-            - -replay.timeFrom=REPLACE_WITH_RFC3339_START_TIME
+            # ~31d before the expected merge date; earlier raw data is outside
+            # retention anyway, so a stale value only yields empty early points.
+            - -replay.timeFrom=2026-06-20T00:00:00Z
             - -replay.disableProgressBar=true
           volumeMounts:
             - name: rules
               mountPath: /rules
               readOnly: true
-      containers:
         - name: replay-derived
           image: victoriametrics/vmalert:v1.147.0
           args:
             - -rule=/rules/derived.yaml
             - -datasource.url=http://vmsingle-vmetrics:8428
             - -remoteWrite.url=http://vmsingle-vmetrics:8428
-            # EDIT ME before applying: keep in sync with the initContainer.
-            - -replay.timeFrom=REPLACE_WITH_RFC3339_START_TIME
+            # Keep in sync with replay-base.
+            - -replay.timeFrom=2026-06-20T00:00:00Z
             - -replay.disableProgressBar=true
           volumeMounts:
             - name: rules
               mountPath: /rules
               readOnly: true
+      containers:
+        - name: reset-rollup-cache
+          image: curlimages/curl:8.11.1
+          args:
+            - -sf
+            - http://vmsingle-vmetrics:8428/internal/resetRollupResultCache
       volumes:
         - name: rules
           configMap:

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/job.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/job.yaml
@@ -1,0 +1,53 @@
+---
+# One-off vmalert replay Job to backfill recording rule history.
+# NOT reconciled by flux — apply manually, see README.md.
+# The initContainer replays the base group first; the main container then
+# replays the derived groups, which read the base rule series. This ordering
+# is required and enforced by the Job structure.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: version-worker-replay
+  namespace: monitoring
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: version-worker-replay
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: replay-base
+          # Pinned to chart 0.86.0's vmalert version (Chart.yaml appVersion v1.147.0).
+          image: victoriametrics/vmalert:v1.147.0
+          args:
+            - -rule=/rules/base.yaml
+            - -datasource.url=http://vmsingle-vmetrics:8428
+            - -remoteWrite.url=http://vmsingle-vmetrics:8428
+            # EDIT ME before applying: RFC3339 start of the backfill window,
+            # normally now-31d (e.g. 2026-06-19T00:00:00Z).
+            - -replay.timeFrom=REPLACE_WITH_RFC3339_START_TIME
+            - -replay.disableProgressBar=true
+          volumeMounts:
+            - name: rules
+              mountPath: /rules
+              readOnly: true
+      containers:
+        - name: replay-derived
+          image: victoriametrics/vmalert:v1.147.0
+          args:
+            - -rule=/rules/derived.yaml
+            - -datasource.url=http://vmsingle-vmetrics:8428
+            - -remoteWrite.url=http://vmsingle-vmetrics:8428
+            # EDIT ME before applying: keep in sync with the initContainer.
+            - -replay.timeFrom=REPLACE_WITH_RFC3339_START_TIME
+            - -replay.disableProgressBar=true
+          volumeMounts:
+            - name: rules
+              mountPath: /rules
+              readOnly: true
+      volumes:
+        - name: rules
+          configMap:
+            name: version-worker-replay-rules

--- a/kubernetes/apps/monitoring/victoria-metrics/replay/kustomization.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/replay/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap-rules.yaml
+  - ./job.yaml


### PR DESCRIPTION
- vmalert evaluates only the version-worker vmrule via ruleselector; notifier.blackhole since no alertmanager is deployed
- recording rules precompute the unique-server aggregates the grafana dashboards currently scan from raw high-cardinality series (base 5m seen-markers + derived 2h/24h/30d windows)
- inert replay/ manifests backfill rule history via vmalert -replay