### PR TITLE
feat: add 1pass_tf_sa_o11y_read to o11y scoped secrets

### DIFF
--- a/tf/deployment/modules/shared/1password/futo-account/o11y-secrets.tf
+++ b/tf/deployment/modules/shared/1password/futo-account/o11y-secrets.tf
@@ -20,6 +20,7 @@ module "o11y-manual-secrets" {
     ]
     scoped = [
       "1PASS_CONNECT_O11Y_READ",
+      "1PASS_TF_SA_O11Y_READ"
     ]
   }
   global_vault      = "o11y_tf_manual"


### PR DESCRIPTION
Adds `1PASS_TF_SA_O11Y_READ` to the o11y manual-secrets scoped list so the module seeds it per env.