### PR TITLE
feat(netbird): allow yucca to reach bootstrap-resources on 443

### DIFF
--- a/tf/deployment/modules/shared/netbird/account/bootstrap.tf
+++ b/tf/deployment/modules/shared/netbird/account/bootstrap.tf
@@ -1,0 +1,25 @@
+# Access to the bootstrap cluster's routed resources — the in-cluster
+# 1Password Connect servers fronted by the Envoy gateway. The group is owned by
+# the infra-bootstrap repo and referenced here by its live account name (verify
+# if it changes), the same way yucca-o11y references it for its talos/CI peers.
+data "netbird_group" "bootstrap_resources" {
+  name = "bootstrap-resources"
+}
+
+# Allow yucca operators' workstations to reach the bootstrap resources over
+# HTTPS — e.g. the onepassword provider talking to opc during local plans.
+resource "netbird_policy" "yucca_to_bootstrap_resources" {
+  name    = "yucca-to-bootstrap-resources"
+  enabled = true
+
+  rule {
+    name          = "yucca-to-bootstrap-resources"
+    action        = "accept"
+    protocol      = "tcp"
+    enabled       = true
+    bidirectional = false
+    sources       = [netbird_group.role["yucca"].id]
+    destinations  = [data.netbird_group.bootstrap_resources.id]
+    ports         = ["443"]
+  }
+}

--- a/tf/deployment/modules/shared/netbird/account/bootstrap.tf
+++ b/tf/deployment/modules/shared/netbird/account/bootstrap.tf
@@ -1,13 +1,8 @@
-# Access to the bootstrap cluster's routed resources — the in-cluster
-# 1Password Connect servers fronted by the Envoy gateway. The group is owned by
-# the infra-bootstrap repo and referenced here by its live account name (verify
-# if it changes), the same way yucca-o11y references it for its talos/CI peers.
 data "netbird_group" "bootstrap_resources" {
   name = "bootstrap-resources"
 }
 
-# Allow yucca operators' workstations to reach the bootstrap resources over
-# HTTPS — e.g. the onepassword provider talking to opc during local plans.
+# Allow yucca operators' workstations to reach the bootstrap resources over HTTPS
 resource "netbird_policy" "yucca_to_bootstrap_resources" {
   name    = "yucca-to-bootstrap-resources"
   enabled = true


### PR DESCRIPTION
Adds an account-wide NetBird policy allowing the yucca group to reach the bootstrap-resources group on tcp/443, one-directional. The group is owned by infra-bootstrap and is referenced by its live account name, the same way yucca-o11y references it for its talos and CI peers. This lets yucca operators' workstations reach the bootstrap cluster's routed resources (the in-cluster 1Password Connect servers behind the Envoy gateway), e.g. for the onepassword provider during local plans.