### PR TITLE
fix(zizmor): fall back to annotations on private repos

### DIFF
--- a/.github/workflows/shared-zizmor.yml
+++ b/.github/workflows/shared-zizmor.yml
@@ -33,3 +33,9 @@ jobs:
         uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           token: ${{ steps.token.outputs.token }}
+          # Uploading SARIF needs code scanning, which requires GitHub
+          # Advanced Security — private repos in this org don't have it, so the
+          # upload fails the run. Zizmor is a required check org-wide, so it has
+          # to keep reporting there: fall back to inline annotations instead.
+          advanced-security: ${{ !github.event.repository.private }}
+          annotations: ${{ github.event.repository.private }}


### PR DESCRIPTION
Zizmor uploads SARIF to code scanning, which requires GitHub Advanced Security. Private repos in this org don't have it, so every run fails.

Zizmor is a required check via the org-wide Required Checks ruleset, so the workflow cannot simply be removed from private repos — the check would never report and PRs would be blocked permanently. Keep it running and emit inline annotations there instead.