### PR TITLE
feat(zizmor): apply default zizmor config if one doesn't exist

### DIFF
--- a/.github/workflows/shared-zizmor.yml
+++ b/.github/workflows/shared-zizmor.yml
@@ -29,6 +29,13 @@ jobs:
           private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
           permission-contents: read
 
+      - name: Fetch org zizmor config
+        run: |
+          mkdir -p .github
+          curl -fsSL --retry 3 --no-clobber \
+            https://raw.githubusercontent.com/immich-app/.github/main/zizmor-config.yml \
+            -o .github/zizmor.yml
+
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:


### PR DESCRIPTION
The org workflows terraform pushes to every repo track @main on purpose: pinning them to a sha would mean a commit to every repo in the org each time a shared workflow changes.

zizmor's unpinned-uses flags those refs. On public repos that is reported via SARIF and exits 0, so it never blocked. On private repos zizmor runs in annotations mode and exits non-zero, failing the required check.

Rather than making zizmor non-blocking on private repos, exempt exactly those two refs via unpinned-uses policies and keep hash pinning mandatory for everything else, so real findings still block.

The config is written at runtime and only when the repo doesn't supply its own, so no file is pushed to any repo.