### PR TITLE
feat(pre-job): expose persist-credentials as an input

### DIFF
--- a/actions/pre-job/action.yml
+++ b/actions/pre-job/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Custom boolean condition to force all jobs to run'
     required: false
     default: 'false'
+  persist-credentials:
+    description: 'Persist git credentials after checkout. Needed on private repos for path filtering on push; leaves the token in .git/config'
+    required: false
+    default: 'false'
 
 outputs:
   should_run:
@@ -192,7 +196,7 @@ runs:
       if: ${{ steps.check-conditions.outputs.needs_path_filtering == 'true' }}
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        persist-credentials: false
+        persist-credentials: ${{ inputs.persist-credentials }}
         token: ${{ inputs.github-token }}
 
     - name: Check force paths


### PR DESCRIPTION
Working out changed paths on a push event shells out to git, which fetches the base commit itself. That fetch is unauthenticated when credentials are not persisted, which is fine on a public repo and fails on a private one:

  fatal: could not read Username for 'https://github.com'

Expose it so a repo that needs it can opt in, rather than changing the behaviour for everyone. Defaults to false, so nothing changes unless a caller sets it.