### PR TITLE
fix(tf): pass the domain through to the pages domain module

### DIFF
--- a/tf/shared/modules/cloudflare-pages-project/project.tf
+++ b/tf/shared/modules/cloudflare-pages-project/project.tf
@@ -24,6 +24,7 @@ module "domain" {
 
   app_name = var.app_name
   env      = var.env
+  domain   = var.domain
 }
 
 resource "cloudflare_web_analytics_site" "analytics" {

--- a/tf/shared/modules/cloudflare-pages/domain.tf
+++ b/tf/shared/modules/cloudflare-pages/domain.tf
@@ -4,6 +4,7 @@ module "domain" {
   app_name = var.app_name
   stage    = var.stage
   env      = var.env
+  domain   = var.domain
 }
 
 data "cloudflare_zone" "domain" {


### PR DESCRIPTION
- `cloudflare-pages` and `cloudflare-pages-project` accept a `domain` variable but never pass it to the inner `domain` module, which defaults to immich.app. A project on another zone therefore gets hostnames under immich.app: the yucca docs preview came out as `docs.pr-623.dev.immich.app.futo.cloud` (immich-app/yucca#623).
- No change for callers on the default domain.